### PR TITLE
fix: remove invalid markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ ApacheCN 账号下没有协议的项目，一律视为 [CC BY-NC-SA 4.0](https:/
 
 ## **鸣谢**
 
-<style>table img {max-width: 200px}</style>
 
 | | | |
 | --- | --- | --- |


### PR DESCRIPTION
github's md does not seems to use css like this and set size behind hyperlink.